### PR TITLE
Set WebFinger content-type to application/jrd+json

### DIFF
--- a/redirect_webfinger/__main__.py
+++ b/redirect_webfinger/__main__.py
@@ -20,7 +20,8 @@ async def handle_webfinger(request: web.Request) -> web.Response:
     return web.json_response(format_response(
         resource=resource,
         mastodon_server=request.app['mastodon_server'],
-        mastodon_user=request.app['mastodon_user']))
+        mastodon_user=request.app['mastodon_user']),
+    content_type='application/jrd+json')
 
 
 def create_app(accts: list[str], mastodon_server: str, mastodon_user: str) -> web.Application:

--- a/test_redirect_webfinger.py
+++ b/test_redirect_webfinger.py
@@ -30,6 +30,7 @@ async def test_valid(aiohttp_client):
     resp = await client.get(
         '/.well-known/webfinger?resource=acct:jelmer@jelmer.uk')
     assert resp.status == 200
+    assert resp.content_type == 'application/jrd+json'
 
     json = await resp.json()
 


### PR DESCRIPTION
Hello, this PR changes the returned `content-type` from `application/json` to `application/jrd+json`. Although it looks like this header doesn't affect the actual behavior, the WebFinger spec specifies the special content-type for WebFinger.

You can see the example response headers in the spec here: [RFC 7033 - WebFinger](https://datatracker.ietf.org/doc/html/rfc7033)

Example response header after the change:

```shell
> curl --head 'localhost:8080/.well-known/webfinger?resource=acct:me@shuuji3.xyz'
HTTP/1.1 200 OK
Content-Type: application/jrd+json; charset=utf-8
Content-Length: 476
Date: Wed, 21 Dec 2022 14:01:41 GMT
Server: Python/3.10 aiohttp/3.8.3
```

We can see the same `content-type` in the official mastodon instance like mastodon.social:

```shell
> curl --head 'https://mastodon.social/.well-known/webfinger?resource=acct:shuuji3@mastodon.social'
HTTP/2 200 
date: Wed, 21 Dec 2022 14:04:08 GMT
content-type: application/jrd+json; charset=utf-8
server: Mastodon
x-frame-options: DENY
x-content-type-options: nosniff
x-xss-protection: 0
permissions-policy: interest-cohort=()
vary: Accept, Origin
cache-control: max-age=259200, public
etag: W/"aa1aa25b1a14d376aec6827105228fb0"
content-security-policy: base-uri 'none'; default-src 'none'; frame-ancestors 'none'; font-src 'self' https://static-cdn.mastodon.social; img-src 'self' https: data: blob: https://static-cdn.mastodon.social; style-src 'self' https://static-cdn.mastodon.social 'nonce-vluQro8QdGuUrSTvf0X1lw=='; media-src 'self' https: data: https://static-cdn.mastodon.social; frame-src 'self' https:; manifest-src 'self' https://static-cdn.mastodon.social; connect-src 'self' data: blob: https://static-cdn.mastodon.social https://files.mastodon.social wss://mastodon.social; script-src 'self' https://static-cdn.mastodon.social 'wasm-unsafe-eval'; child-src 'self' blob: https://static-cdn.mastodon.social; worker-src 'self' blob: https://static-cdn.mastodon.social
x-request-id: 3cb6a8e3-7eb2-4fdc-9a4e-b603afeade82
x-runtime: 1.434102
strict-transport-security: max-age=63072000; includeSubDomains
x-cached: HIT
```